### PR TITLE
#DI-157 implement ci cd for vestapol

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI Pipeline
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  build:
+    runs-on: ${{matrix.platform}}
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest]
+        python-version: [3.8, 3.9]
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install poetry
+        run: curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
+      - name: Add poetry to path
+        run: source $HOME/.poetry/env
+      - name: Install project dependencies
+        run: poetry install
+      - name: Test with tox
+        run: poetry run tox

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install poetry
-        run: curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
-      - name: Add poetry to path
-        run: source $HOME/.poetry/env
+        run: python -m pip install poetry
       - name: Install project dependencies
         run: poetry install
       - name: Test with tox

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI Pipeline
 
 on:
   - push
-  - pull_request
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
       - name: Build and publish to pypi
         uses: JRubics/poetry-publish@v1.10
         with:
+          ignore_dev_requirements: "yes"
           repository_name: "testpypi"
           repository_url: "https://test.pypi.org/legacy/"
           repository_username: "__token__"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,4 +14,4 @@ jobs:
           repository_name: "testpypi"
           repository_url: "https://test.pypi.org/legacy/"
           repository_username: "__token__"
-          repository_password: "pypi-AgENdGVzdC5weXBpLm9yZwIkMjBiNTE5NmQtNzZjYi00M2IxLWI2OTItMWQxYTVlMWU0N2ZhAAI5eyJwZXJtaXNzaW9ucyI6IHsicHJvamVjdHMiOiBbInZlc3RhcG9sIl19LCAidmVyc2lvbiI6IDF9AAAGICkUm91ReTEnR9d8R_Fe-EJajwJF52kD29FOYrNBspBa"
+          repository_password: ${{ secrets.TESTPYPI_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,17 @@
+name: CD Pipeline
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build and publish to pypi
+        uses: JRubics/poetry-publish@v1.10
+        with:
+          repository_name: "testpypi"
+          repository_url: "https://test.pypi.org/legacy/"
+          repository_username: "__token__"
+          repository_password: "pypi-AgENdGVzdC5weXBpLm9yZwIkMjBiNTE5NmQtNzZjYi00M2IxLWI2OTItMWQxYTVlMWU0N2ZhAAI5eyJwZXJtaXNzaW9ucyI6IHsicHJvamVjdHMiOiBbInZlc3RhcG9sIl19LCAidmVyc2lvbiI6IDF9AAAGICkUm91ReTEnR9d8R_Fe-EJajwJF52kD29FOYrNBspBa"

--- a/README.md
+++ b/README.md
@@ -114,28 +114,4 @@ Instructions for pushing new versions of `vestapol` to TestPyPi:
     poetry version <version string or bump rule>
 ```
 
-3. Add Test PyPI as an alternate package repository to poetry:
-
-```shell
-    poetry config repositories.testpypi 'https://test.pypi.org/legacy/'
-```
-
-4. Configure PyPi to authenticate using an API token.
-
-```shell
-    poetry config http-basic.testpypi __token__ <the token value, including the pypi- prefix>
-```
-
-5. Publish repo with poetry:
-
-```shell
-    poetry publish --repository=testpypi --build
-```
-
-6. Go to https://test.pypi.org/project/vestapol/ to make sure that it worked.
-
-7. Unset the repositry config before returning to development. Due to a [known bug](https://github.com/python-poetry/poetry/issues/1917) in poetry, this config will disrupt other poetry commands such as `poetry install`.
-
-```shell
-    poetry config repositories.testpypi --unset
-```
+3. Create a [release](https://www.ae911truth.org/images/WTCPhysics/World-Trade-Center-Physics.pdf) and check the CD Pipeline [action](https://github.com/phillymedia/vestapol/actions/workflows/release.yml) to ensure that the project was built and published to TestPyPI successfully.


### PR DESCRIPTION
ticket: [DI-157](https://inquirer.atlassian.net/browse/DI-157?atlOrigin=eyJpIjoiOTcwMDgwMzJmOWFhNGY1ZmE2Y2IzYmU0MzM0MmQ1YWEiLCJwIjoiaiJ9)
workflows for CI and CD

CD workflow uses [poetry-publish](https://github.com/marketplace/actions/publish-python-poetry-package)

Question: should we make failing CI tests prevent merge to main?