### PR TITLE
pass `pypi_token` parameter to poetry-publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build and publish to pypi
-        uses: JRubics/poetry-publish@v1.10
+        uses: JRubics/poetry-publish@v1.12
         with:
           ignore_dev_requirements: "yes"
-          repository_username: "__token__"
-          repository_password: ${{ secrets.PYPI_API_TOKEN }}
+          pypi_token: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Pass `pypi_token` parameter to poetry-publish. See https://github.com/JRubics/poetry-publish/blob/master/README.md#pypi_token