### PR TITLE
Add "quoted newlines" optional config when creating GBQ table

### DIFF
--- a/tests/destinations/test_gcp_destination.py
+++ b/tests/destinations/test_gcp_destination.py
@@ -35,6 +35,7 @@ def test_create_table(mock):
     )
 
     resource.skip_leading_rows = 123
+    resource.allow_quoted_newlines = True
 
     # Can't set the "name" attribute when instantiating a MagicMock
     resource.name = "dummy_resource"
@@ -76,4 +77,5 @@ def test_create_table(mock):
             ),
         ],
         123,
+        True,
     )

--- a/tests/web_resources/test_csv_resource.py
+++ b/tests/web_resources/test_csv_resource.py
@@ -15,8 +15,9 @@ def mock_csv_resource():
     endpoint = "/dummy"
     version = "v99.9"
     skip_leading_rows = 123
+    allow_quoted_newlines = True
     mock_csv_resource = csv_resource.CSVResource(
-        name, base_url, endpoint, version, skip_leading_rows
+        name, base_url, endpoint, version, skip_leading_rows, allow_quoted_newlines
     )
     mock_csv_resource.requested_at = DateTime(1970, 1, 1)
     return mock_csv_resource

--- a/vestapol/destinations/gcp_destination.py
+++ b/vestapol/destinations/gcp_destination.py
@@ -74,6 +74,7 @@ class GoogleCloudPlatform(base_destination.BaseDestination):
             source_uris,
             table_schema,
             resource.skip_leading_rows,
+            resource.allow_quoted_newlines,
         )
 
         tablename_fq = f"{self.gbq_project_id}.{self.gbq_dataset_id}.{tablename}"

--- a/vestapol/external_tables.py
+++ b/vestapol/external_tables.py
@@ -19,6 +19,7 @@ def get_external_data_configuration(
     source_format: str,
     table_schema: Optional[List[bigquery.SchemaField]] = None,
     skip_leading_rows: int = 0,
+    allow_quoted_newlines: Optional[bool] = False,
 ):
 
     bq_source_format = {"jsonl": "NEWLINE_DELIMITED_JSON", "csv": "CSV"}[source_format]
@@ -42,6 +43,7 @@ def get_external_data_configuration(
     if bq_source_format == "CSV":
         # skips mypy since Google does not give CSVOptions a signature
         external_config.csv_options.skip_leading_rows = skip_leading_rows  # type: ignore # noqa: E501
+        external_config.csv_options.allow_quoted_newlines = allow_quoted_newlines  # type: ignore # noqa: E501
 
     return external_config
 
@@ -56,6 +58,7 @@ def create_gcp_table(
     source_uris: List[str],
     table_schema: Optional[List[bigquery.SchemaField]],
     skip_leading_rows: int = 0,
+    allow_quoted_newlines: Optional[bool] = False,
 ):
 
     client = bigquery.Client()
@@ -71,6 +74,7 @@ def create_gcp_table(
         source_format,
         table_schema,
         skip_leading_rows,
+        allow_quoted_newlines,
     )
 
     # Create a permanent table linked to the GCS file

--- a/vestapol/web_resources/base_resource.py
+++ b/vestapol/web_resources/base_resource.py
@@ -31,6 +31,7 @@ class BaseResource(ABC):
         request_headers: dict = None,
         manual_schema=None,
         skip_leading_rows: int = 0,
+        allow_quoted_newlines: Optional[bool] = False,
     ):
         self.name = name
         self.base_url = base_url
@@ -44,6 +45,7 @@ class BaseResource(ABC):
         self.manual_schema = manual_schema
         self.requested_at = DateTime.utcnow().replace(microsecond=0)
         self.skip_leading_rows = skip_leading_rows
+        self.allow_quoted_newlines = allow_quoted_newlines
 
     def load(self, destination: BaseDestination):
         """The main entry point method for Vestapol resources. This method

--- a/vestapol/web_resources/csv_resource.py
+++ b/vestapol/web_resources/csv_resource.py
@@ -28,6 +28,7 @@ class CSVResource(base_resource.BaseResource):
         query_params: dict = None,
         request_headers: dict = None,
         manual_schema: List[Dict] = None,
+        allow_quoted_newlines: Optional[bool] = False,
     ):
         self.name = name
         self.base_url = base_url
@@ -37,6 +38,7 @@ class CSVResource(base_resource.BaseResource):
         self.query_params = query_params
         self.request_headers = request_headers
         self.manual_schema = manual_schema
+        self.allow_quoted_newlines = allow_quoted_newlines
 
         super().__init__(
             self.name,
@@ -50,6 +52,7 @@ class CSVResource(base_resource.BaseResource):
             self.request_headers,
             self.manual_schema,
             self.skip_leading_rows,
+            self.allow_quoted_newlines,
         )
 
     def write_data(self, data, destination: BaseDestination):


### PR DESCRIPTION
Added quoted newlines" optional config: allow_quoted_newlines

- allow_quoted_newlines: Indicates whether to allow quoted data sections that contain newline characters in a CSV file. The default value is false. (Read more: https://stackoverflow.com/a/33698962/8884544)
