### PR TITLE
🔥 Remove extraneous return statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,3 +81,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.0.24] - 2024-03-07
 - Updated the parameter data type in write_list (json_resource class)
+
+## [0.0.26] - 2024-04-29
+- Updated the parameter data type in write_list (json_resource class)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "vestapol"
-version = "0.0.25"
+version = "0.0.26"
 description = "Python package that loads data from the web and deploys a corresponding external table definition, so that the data can be queried using standard SQL."
 authors = ["Brian Waligorski <bwaligorski@inquirer.com>"]
 license = "Apache License 2.0"

--- a/vestapol/web_resources/base_resource.py
+++ b/vestapol/web_resources/base_resource.py
@@ -63,7 +63,6 @@ class BaseResource(ABC):
         """
         data = self.request_data()
         self.write_data(data, destination)
-        return data  # TODO: I think we can remove this return statement
 
     def request_data(self):
         """Method that encapsulates the call to an API or other web resource. It

--- a/vestapol/web_resources/json_resource.py
+++ b/vestapol/web_resources/json_resource.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 from abc import abstractmethod
 from typing import Any
 from typing import Dict
+from typing import Generator
 from typing import List
 from typing import Optional
 from typing import Tuple
-from typing import Generator
 from typing import TYPE_CHECKING
 
 from vestapol.web_resources import base_resource
@@ -55,7 +55,6 @@ class JSONResource(base_resource.BaseResource):
         data = self.request_data()
         self.write_data(data, destination)
         self.unnest_data(data, destination)
-        return data
 
     def write_data(self, api_data, destination: BaseDestination):
         json_writer.write_json(


### PR DESCRIPTION
Removes extraneous `return` statements in `BaseResource.load` and it's subclassed methods. These return values are not used and likely bloat the memory footprint of calls to `load`