### PR TITLE
DI-4546: removing deprecated command from vestapol CD workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build and publish to pypi
-        uses: JRubics/poetry-publish@v1.12
+        uses: JRubics/poetry-publish@v2.1
         with:
-          ignore_dev_requirements: "yes"
+          poetry_install_options: "--without dev"
           pypi_token: ${{ secrets.PYPI_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Instructions for pushing new versions of `vestapol` to PyPI:
 
 1. Update `CHANGELOG.md`. Include Additions, Fixes, and Changes.
 
-2. Update project version using either a valid [PEP 440 string](https://peps.python.org/pep-0440/) or a [valid bump rule](https://python-poetry.org/docs/master/cli/#version) following [Semantic Versioning](http://semver.org/).
+2. Update project version using either a valid [PEP 440 string](https://peps.python.org/pep-0440/) or a [valid bump rule](https://python-poetry.org/docs/cli/#version) following [Semantic Versioning](http://semver.org/).
 
 ```shell
     poetry version <version string or bump rule>


### PR DESCRIPTION
https://github.com/JRubics/poetry-publish#:~:text=Note%3A%20ignore_dev_requirements%20command%20is%20deprecated%20in%20version%202.0.%20Use%20poetry_install_options%3A%20%22%2D%2Dwithout%20dev%22%20instead

trying to fix this failure: https://github.com/phillymedia/vestapol/actions/runs/17329550966/job/49207131245
The option "--no-dev" does not exist
